### PR TITLE
Fixed lower bound for linear equations in Flow

### DIFF
--- a/matlab/snsolve.m
+++ b/matlab/snsolve.m
@@ -184,7 +184,7 @@ Fmul    =  zeros(nCon,1);
 Fstate  =  zeros(nCon,1);
 ObjAdd  =  0;
 ObjRow  =  1;
-Flow    = [ -inf; -inf*ones(nli,1); zeros(nle,1); -inf*ones(mi,1); zeros(me,1) ];
+Flow    = [ -inf; -inf*ones(nli,1); zeros(nle,1); -inf*ones(mi,1); beq ];
 Fupp    = [  inf; zeros(nli,1); zeros(nle,1); b; beq ];
 
 


### PR DESCRIPTION
Linear equality constraints in the reformulated problem were given as 0 <= Aeq x <= beq, but the lower bound in Flow probably should have been beq <= Aeq x <= beq.

Nonetheless, thanks for the great work on snopt.

Best,
  Christian